### PR TITLE
feat: refactored Mocker simulator and other fixes

### DIFF
--- a/.github/workflows/release_deploy.yml
+++ b/.github/workflows/release_deploy.yml
@@ -90,7 +90,7 @@ jobs:
     steps:
       - name: Make Release
         id: release
-        uses: pagopa/github-actions-template/node-release@v1.6.6
+        uses: pagopa/github-actions-template/node-release@d2952cbcfaf4708ff5aeabdacf24056d082b8034
         with:
           semver: ${{ needs.setup.outputs.semver }}
           github_token: ${{ secrets.BOT_TOKEN_GITHUB }}

--- a/src/pages/mocker/configuration/CreateMockResource.tsx
+++ b/src/pages/mocker/configuration/CreateMockResource.tsx
@@ -108,9 +108,9 @@ export default class CreateMockResource extends React.Component<IProps, IState> 
   render(): React.ReactNode {
     this.redirectOnSuccess();
     return (
-      <Grid container mb={11}>
-        <Grid item p={3} xs={11}>
-          <Stack direction="row" mt={2}>
+      <Grid container mb={12}>
+        <Grid item xs={12}>
+          <Stack direction="row">
             <ButtonNaked size="small" component="button" onClick={() => this.redirectToPreviousPage()} startIcon={<ArrowBack/>} sx={{color: 'primary.main', mr: '20px'}} weight="default">
               Back
             </ButtonNaked>

--- a/src/pages/mocker/configuration/CreateMockRule.tsx
+++ b/src/pages/mocker/configuration/CreateMockRule.tsx
@@ -152,9 +152,9 @@ export default class CreateMockRule extends React.Component<IProps, IState> {
   render(): React.ReactNode {
     this.redirectOnSuccess();
     return (
-      <Grid container mb={11}>
-        <Grid item p={3} xs={11}>
-          <Stack direction="row" mt={2}>
+      <Grid container mb={12}>
+        <Grid item xs={12}>
+          <Stack direction="row">
             <ButtonNaked size="small" component="button" onClick={() => this.redirectToPreviousPage()} startIcon={<ArrowBack/>} sx={{color: 'primary.main', mr: '20px'}} weight="default">
               Back
             </ButtonNaked>

--- a/src/pages/mocker/configuration/EditMockResource.tsx
+++ b/src/pages/mocker/configuration/EditMockResource.tsx
@@ -153,9 +153,9 @@ export default class EditMockResource extends React.Component<IProps, IState> {
   render(): React.ReactNode {
     this.redirectOnSuccess();
     return (
-      <Grid container mb={11}>
-        <Grid item p={3} xs={11}>
-          <Stack direction="row" mt={2}>
+      <Grid container mb={12}>
+        <Grid item xs={12}>
+          <Stack direction="row">
             <ButtonNaked size="small" component="button" onClick={() => this.redirectToPreviousPage()} startIcon={<ArrowBack/>} sx={{color: 'primary.main', mr: '20px'}} weight="default">
               Back
             </ButtonNaked>

--- a/src/pages/mocker/configuration/EditMockRule.tsx
+++ b/src/pages/mocker/configuration/EditMockRule.tsx
@@ -154,9 +154,9 @@ export default class EditMockRule extends React.Component<IProps, IState> {
   render(): React.ReactNode {
     this.redirectOnSuccess();
     return (
-      <Grid container mb={11}>
-        <Grid item p={3} xs={11}>
-          <Stack direction="row" mt={2}>
+      <Grid container mb={12}>
+        <Grid item xs={12}>
+          <Stack direction="row">
             <ButtonNaked size="small" component="button" onClick={() => this.redirectToPreviousPage()} startIcon={<ArrowBack/>} sx={{color: 'primary.main', mr: '20px'}} weight="default">
               Back
             </ButtonNaked>

--- a/src/pages/mocker/configuration/ShowMockResourceDetail.tsx
+++ b/src/pages/mocker/configuration/ShowMockResourceDetail.tsx
@@ -112,7 +112,7 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
             const problemJson = response as ProblemJson;
             if (problemJson.status === 404) {
               toastError(`No mock resource found with id ${this.state.mockResource?.id!}.`);
-            } else if (problemJson.status === 404) {
+            } else if (problemJson.status === 400) {
               toastError(`There are three or more rules with same order, the swap is not possible.`);
             } else if (problemJson.status === 500) {
               toastError(`An error occurred while updating general info for mock resource.`);

--- a/src/pages/mocker/configuration/ShowMockResourceDetail.tsx
+++ b/src/pages/mocker/configuration/ShowMockResourceDetail.tsx
@@ -5,17 +5,16 @@ import { AuthenticationResult } from "@azure/msal-browser";
 import { MockerConfigApi } from "../../../util/apiclient";
 import { isErrorResponse } from "../../../util/client-utils";
 import { ProblemJson } from "../../../api/generated/mocker-config/ProblemJson";
-import { generateCURLRequest, getFormattedCondition, stringfyList, toastError } from "../../../util/utilities";
+import { generateCURLRequest, getFormattedBody, getFormattedCondition, getFormattedResponseInfo, toastError, toastOK } from "../../../util/utilities";
 import { MockResource } from "../../../api/generated/mocker-config/MockResource";
-import { Accordion, AccordionDetails, AccordionSummary, Box, Chip, Divider, Grid, Paper, Stack, TextField, Tooltip, Typography } from '@mui/material';
+import { Accordion, AccordionDetails, AccordionSummary, Box, Chip, Divider, Grid, Paper, Stack, TextField, Typography } from '@mui/material';
 import { ButtonNaked } from '@pagopa/mui-italia';
-import { Add, ArrowBack, CheckCircleOutline, Delete, Edit, ExpandMore, Help, HighlightOff, PlayCircle, Save, SwapVert } from '@mui/icons-material';
+import { Add, ArrowBack, CheckCircleOutline, ContentCopy, Delete, Edit, ExpandMore, HighlightOff, PlayCircle, Save, SwapVert } from '@mui/icons-material';
 import Title from "../../../components/pages/Title";
-import xmlFormat from "xml-formatter";
-import { MockResponse } from "../../../api/generated/mocker-config/MockResponse";
 import GenericModal from "../../../components/generic/GenericModal";
 import { SpecialRequestHeader } from "../../../api/generated/mocker-config/SpecialRequestHeader";
 import { ENV as env } from "../../../util/env";
+import { getActivationStatusTooltip, getRuleConditionTooltip, getSpecialHeadersTooltip } from "../../../util/tooltips";
 
 interface IProps {
     match: {
@@ -35,7 +34,13 @@ interface IProps {
     showDeleteConditionModal: boolean,
     targetRule: string,
     targetCondition: string,
+    resourceCURL: string,
     swappingOrder: boolean,
+    swappedRules: {
+      ruleId: string,
+      prevOrder: number,
+      nextOrder: number,
+    }[]
   }
 
 export default class ShowMockResourceDetail extends React.Component<IProps, IState> {
@@ -54,7 +59,9 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
       showDeleteConditionModal: false,
       targetRule: '',
       targetCondition: '',
-      swappingOrder: false
+      resourceCURL: '',
+      swappingOrder: false,
+      swappedRules: []
     };
 
     this.readMockResource.bind(this);
@@ -78,7 +85,8 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
               toastError(`An error occurred while retrieving mock resource with id ${resourceId}.`);
             }
         } else {
-          this.setState({ mockResource: response });    
+          const cURL = generateCURLRequest(`${env.MOCKER.HOST}` + `${env.MOCKER.BASEPATH}${response?.subsystem}/${response?.resource_url ? response.resource_url : ''}`.replace(/\/\//gm, ""), response, false)
+          this.setState({ mockResource: response, resourceCURL: cURL });    
         }
       })
       .catch(() => {
@@ -92,6 +100,7 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
 
   updateResource = (): void => {
     this.setState({ isContentLoading: true });
+    this.updateSwappedRules();
     this.context.instance.acquireTokenSilent({
       ...loginRequest,
       account: this.context.accounts[0]
@@ -103,6 +112,8 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
             const problemJson = response as ProblemJson;
             if (problemJson.status === 404) {
               toastError(`No mock resource found with id ${this.state.mockResource?.id!}.`);
+            } else if (problemJson.status === 404) {
+              toastError(`There are three or more rules with same order, the swap is not possible.`);
             } else if (problemJson.status === 500) {
               toastError(`An error occurred while updating general info for mock resource.`);
             }
@@ -228,38 +239,42 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
     }}></Chip>)
   }
 
-  getFormattedResponseInfo(response: MockResponse) {
-    let headers = response.headers.map(header => 
-      <Typography variant="body2" sx={{ fontSize: '14px'}}>
-        <b>{header.name}:</b> <Typography variant="caption" sx={{ fontSize: '14px'}}>{header.value}</Typography>
-      </Typography>
-    );
-    let injected_parameters = response.injected_parameters && response.injected_parameters.length > 0 ? stringfyList(response.injected_parameters) : 'none'
-    return (
-      <Box>
-        <Typography variant="body2" sx={{ fontSize: '14px'}}>
-          <b>Status:</b> <Typography variant="caption" sx={{ fontSize: '14px'}}>{response.status}</Typography>
-        </Typography>
-        <Typography variant="body2" sx={{ fontSize: '14px', marginBottom: 1 }}>
-          <b>Injectable parameters:</b> <Typography variant="caption" sx={{ fontSize: '14px'}}>{injected_parameters}</Typography>
-        </Typography>
-        <Divider/>
-        {headers}
-      </Box>
-    );
+  copyCURL() {
+    navigator.clipboard.writeText(this.state.resourceCURL);
+    toastOK("Resource cURL copied to clipboard!");
   }
 
-  getFormattedBody(body: string | undefined) {
-    if (body === undefined) {
-      return 'No body';
+  swapRuleOrder(ruleId: string, order: number): any {    
+    let swappedRules = this.state.swappedRules;
+    let analyzedSwappedRule = swappedRules.find((rule) => rule.ruleId === ruleId);
+    if (analyzedSwappedRule !== undefined) {
+      analyzedSwappedRule.nextOrder = order;
+    } else {
+      analyzedSwappedRule = {
+        ruleId,
+        prevOrder: this.state.mockResource!.rules.find((rule) => rule.id === ruleId)?.order!,
+        nextOrder: order,
+      }
+      swappedRules.push(analyzedSwappedRule);
     }
-    let decodedBody = atob(body);
-    if (decodedBody.startsWith("{")) {
-      return JSON.stringify(JSON.parse(decodedBody), null, 2);
-    } else if (decodedBody.startsWith("<")) {
-      return xmlFormat(decodedBody, {collapseContent: true});
-    }
-    return decodedBody;
+    let mockResource = this.state.mockResource;
+    let rule = mockResource?.rules.find((rule) => rule.id === ruleId);
+    rule!.order = order;
+    this.setState({ mockResource, swappedRules });
+  }
+
+  updateSwappedRules() {
+    let swappedRules = this.state.swappedRules;
+    let mockResource = this.state.mockResource;
+    let alreadySwapped: string[] = [];
+    swappedRules.forEach((swappedRule) => {
+      let ruleToBeSwapped = mockResource?.rules.find((rule) => rule.order === swappedRule.nextOrder && rule.id !== swappedRule.ruleId);
+      if (ruleToBeSwapped !== undefined && !alreadySwapped.includes(ruleToBeSwapped.id!)) {
+        ruleToBeSwapped.order = swappedRule.prevOrder;
+        alreadySwapped.push(ruleToBeSwapped.id!);
+      }
+    });
+    this.setState({ mockResource });
   }
 
   activateSwapOrder() {
@@ -271,6 +286,10 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
     this.setState({ swappingOrder: false });
   }
 
+  serializeCURL(): string {
+    let curl = generateCURLRequest(`${env.MOCKER.HOST}` + `${env.MOCKER.BASEPATH}${this.state.mockResource?.subsystem}/${this.state.mockResource?.resource_url ? this.state.mockResource.resource_url : ''}`.replace(/\/\//gm, ""), this.state.mockResource, true);
+    return btoa(curl);
+  }
 
 
   redirectToEditGeneralInfoPage(): void {
@@ -283,7 +302,7 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
     this.props.history.push(`/mocker/mock-resources/${this.state.mockResource?.id}/rules/${ruleId}/edit`);
   }
   redirectToSimulatorPage(): void {
-    this.props.history.push(`/mocker/simulation`);
+    this.props.history.push(`/mocker/simulation?curl=${this.serializeCURL()}`);
   }
   redirectToPreviousPage() {
     this.props.history.goBack();
@@ -309,15 +328,14 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
     this.readMockResource(this.props.match.params['id'] as string);
   }
 
-
   
   render(): React.ReactNode {
     let mockResource = this.state.mockResource;
 
     return (
-      <Grid container mb={11}>
-        <Grid item p={3} xs={11}>
-          <Stack direction="row" mt={2}>
+      <Grid container mb={12}>
+        <Grid item xs={12}>
+          <Stack direction="row">
             <ButtonNaked size="small" component="button" onClick={() => this.redirectToPreviousPage()} startIcon={<ArrowBack/>} sx={{color: 'primary.main', mr: '20px'}} weight="default">
               Back
             </ButtonNaked>
@@ -331,7 +349,6 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
                 mbTitle={1}
                 variantTitle="h4"
                 variantSubTitle="subtitle1"
-                titleFontColor="#1976d2"
                 subTitleFontSize='14px'
                 subTitleFontColor="#757575"
               />
@@ -368,15 +385,7 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
               <Grid item xs={3}>
                 <Typography variant="subtitle1" sx={{fontWeight: 'bold'}}>
                   Status
-                  <Tooltip sx={{ paddingLeft: '5px'}} title={
-                    <div>
-                      This field represents the activation status of the mock resource.<br/>
-                      If the mock resource is in "active" state, Mocker can evaluate its rules if the request is compliant with this resource. <br/>
-                      If the mock resource is in "inactive" state, Mocker does not evaluate the rules that make it up and returns a generic error message.
-                    </div>
-                  }>
-                    <Help sx={{ color: "#61affe" }}></Help>
-                  </Tooltip>
+                  {getActivationStatusTooltip()}
                 </Typography>
                 { mockResource?.is_active && <CheckCircleOutline color="success" /> }
                 { !mockResource?.is_active && <HighlightOff color="error"/> }
@@ -386,15 +395,7 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
               <Grid item xs={9}>
                 <Typography variant="subtitle1" sx={{fontWeight: 'bold'}}>
                   Special headers
-                  <Tooltip sx={{ paddingLeft: '5px'}} title={
-                      <div>
-                        This field represents the set of special headers to be tightly bound to the mock resource.<br/>
-                        If a request is compliant with the mock resource and contains these headers with the defined values, Mocker may evaluate the mock rules and return a response.<br/>
-                        If a request does not have all the headers defined with the same set values, Mocker does not consider the request to be compliant with this mock resource.
-                      </div>
-                    }>
-                    <Help sx={{ color: "#61affe" }}></Help>
-                  </Tooltip>
+                  {getSpecialHeadersTooltip()}
                 </Typography>
                 <>{this.getFormattedSpecialHeaders(mockResource?.special_headers || [])}</>
               </Grid>
@@ -411,16 +412,14 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
                   Resource cURL
                 </Typography>
                 <Box sx={{ width: '100%', marginBottom: 2, borderRadius: 4, p: 1, backgroundColor: '#f6f6f6', typography: 'caption' }}>
+                  <ButtonNaked component="button" onClick={() => this.copyCURL()} startIcon={<ContentCopy/>} sx={{ color: 'primary.main' }}>
+                    Copy
+                  </ButtonNaked>
                   <ButtonNaked component="button" onClick={() => this.redirectToSimulatorPage()} startIcon={<PlayCircle/>} sx={{ color: 'green' }}>
                     Test it!
                   </ButtonNaked>
                   <Box sx={{ marginBottom: 1, marginTop: 1, borderRadius: 4, p: 1, backgroundColor: 'white', fontSize: '8px', typography: 'caption', whiteSpace: 'pre-wrap' }}>
-                    {
-                      generateCURLRequest(
-                        `${env.MOCKER.HOST}` + `${env.MOCKER.BASEPATH}${mockResource?.subsystem}/${mockResource?.resource_url ? mockResource.resource_url : ''}`.replace(/\/\//gm, ""),
-                        mockResource
-                      )            
-                    }                
+                    {this.state.resourceCURL}                
                   </Box>
                 </Box>
               </Grid>
@@ -463,7 +462,7 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
                       <Grid item xs={1}>
                         {
                           this.state.swappingOrder === true && !rule.tags.includes('Parachute') &&
-                          <TextField id="order" label=" " type="number" value={rule.order} onChange={(event) => rule.order = event.target.value as unknown as number} sx={{ width: '70%' }} size="small" inputProps={{ max: 9999, min: 1, style: { fontSize: 13, padding: 0, paddingLeft: 10 } }} InputLabelProps={{ shrink: false }}/>
+                          <TextField id="order" label=" " type="number" value={rule.order} onChange={(event) => this.swapRuleOrder(rule.id!, Number(event.target.value))} sx={{ width: '70%' }} size="small" inputProps={{ max: 9999, min: 1, style: { fontSize: 13, padding: 0, paddingLeft: 10 } }} InputLabelProps={{ shrink: false }}/>
                         }
                         {
                           (this.state.swappingOrder === false || rule.tags.includes('Parachute')) &&
@@ -501,7 +500,10 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
                       </Grid>
                       
                       <Grid container alignItems={'center'} spacing={0} mb={2}>
-                        <Typography variant="subtitle1" sx={{fontWeight: 'bold'}}>Conditions</Typography>
+                        <Typography variant="subtitle1" sx={{fontWeight: 'bold'}}>
+                          Conditions
+                          {getRuleConditionTooltip()}
+                        </Typography>
                         <Grid container alignItems={'center'} spacing={0}>
                           { rule.conditions && rule.conditions.length > 0 && 
                             <ol>
@@ -526,9 +528,9 @@ export default class ShowMockResourceDetail extends React.Component<IProps, ISta
                         <Grid item sx={{ width: '100%' }}>
                           <Typography variant="subtitle1" sx={{fontWeight: 'bold'}}>Response</Typography>
                           <Box sx={{ width: '100%', marginBottom: 2, borderRadius: 4, p: 1, backgroundColor: '#f6f6f6', typography: 'caption' }}>
-                            {this.getFormattedResponseInfo(rule.response)}
+                            {getFormattedResponseInfo(rule.response)}
                             <Box sx={{ marginBottom: 1, marginTop: 1, borderRadius: 4, p: 1, backgroundColor: 'white', fontSize: '8px', typography: 'caption', whiteSpace: 'pre-wrap' }}>
-                              {this.getFormattedBody(rule.response.body)}
+                              {getFormattedBody(rule.response.body)}
                             </Box>
                           </Box>
                         </Grid>

--- a/src/pages/mocker/forms/MockResourceHandlingForm.tsx
+++ b/src/pages/mocker/forms/MockResourceHandlingForm.tsx
@@ -4,6 +4,7 @@ import { Paper, Grid, Typography, Divider, Select, MenuItem, Switch, FormControl
 import React from "react";
 import { MockResponse } from "../../../api/generated/mocker-config/MockResponse";
 import { stringfyList } from "../../../util/utilities";
+import { getInjectedParameterTooltip, getSpecialHeadersTooltip } from "../../../util/tooltips";
 
 
 type Props = {
@@ -188,7 +189,7 @@ export const MockResourceHandlingForm = ({redirectToPreviousPage, onSubmitShowMo
         </Grid>
         <Grid container alignItems={"center"} spacing={1} mb={2}>
           <Grid item xs={12}>
-            <TextField id="stringified_special_headers" label="Special Headers" placeholder="SOAPAction:x, X-Host-Url:y, ..." disabled={operation === "EDIT"} value={formik.values.stringified_special_headers} onChange={formik.handleChange} error={formik.touched.stringified_special_headers && Boolean(formik.errors.stringified_special_headers)} InputLabelProps={{ shrink: true }} sx={{ width: "100%" }}/>
+            <TextField id="stringified_special_headers" label={<>Special Headers (split by comma) {getSpecialHeadersTooltip()}</>} placeholder="SOAPAction:value1, X-Host-Url:value2, ..." disabled={operation === "EDIT"} value={formik.values.stringified_special_headers} onChange={formik.handleChange} error={formik.touched.stringified_special_headers && Boolean(formik.errors.stringified_special_headers)} InputLabelProps={{ shrink: true }} sx={{ width: "100%" }}/>
           </Grid>
         </Grid>
         <Grid container alignItems={"center"} spacing={1} mb={2}>
@@ -214,7 +215,7 @@ export const MockResourceHandlingForm = ({redirectToPreviousPage, onSubmitShowMo
               <TextField id="status" label="Status code" type="number" placeholder="200" value={formik.values.status} onChange={formik.handleChange} error={formik.touched.status && Boolean(formik.errors.status)} InputLabelProps={{ shrink: true }} sx={{ width: "100%" }}/>
             </Grid>
             <Grid item xs={10}>
-              <TextField id="injected_parameters" label="Injected parameters (split by comma)" placeholder="req.param1.value1, req.param2.value2, ..." value={formik.values.injected_parameters} onChange={formik.handleChange} error={formik.touched.injected_parameters && Boolean(formik.errors.injected_parameters)} InputLabelProps={{ shrink: true }} sx={{ width: "100%" }}/>
+              <TextField id="injected_parameters" label={<>Injected parameters (split by comma) {getInjectedParameterTooltip()}</>} placeholder="req.param1.value1, req.param2.value2, ..." value={formik.values.injected_parameters} onChange={formik.handleChange} error={formik.touched.injected_parameters && Boolean(formik.errors.injected_parameters)} InputLabelProps={{ shrink: true }} sx={{ width: "100%" }}/>
             </Grid>
           </Grid>
           <Grid container alignItems={"center"} spacing={1} mb={2}>
@@ -224,7 +225,7 @@ export const MockResourceHandlingForm = ({redirectToPreviousPage, onSubmitShowMo
           </Grid>
           <Grid container alignItems={"center"} spacing={1} mb={2}>
             <Grid item xs={12}>
-              <TextField id="body" multiline label="Parachute body response (in string, XML or JSON)" rows={20} value={formik.values.body} onChange={formik.handleChange} InputLabelProps={{ shrink: true }} sx={{ width: '100%', fontSize: '8px', typography: 'caption' }} />
+              <TextField id="body" multiline label="Parachute body response (in string, XML or JSON)" rows={20} value={formik.values.body} onChange={formik.handleChange} InputProps={{ sx: {fontSize: '8px', typography: 'caption'} }} InputLabelProps={{ shrink: true }} sx={{ width: '100%', fontSize: '8px', typography: 'caption' }} />
             </Grid>
           </Grid>
         </Paper>

--- a/src/pages/mocker/forms/MockRuleHandlingForm.tsx
+++ b/src/pages/mocker/forms/MockRuleHandlingForm.tsx
@@ -9,6 +9,7 @@ import { ComplexContentTypeEnum } from "../../../util/constants";
 import { Add, CheckCircleOutline, Delete, HighlightOff } from "@mui/icons-material";
 import { ButtonNaked } from "@pagopa/mui-italia";
 import { MockResponse } from "../../../api/generated/mocker-config/MockResponse";
+import { getInjectedParameterTooltip, getRuleConditionTooltip } from "../../../util/tooltips";
 
 type Props = {
   redirectToPreviousPage: () => void,
@@ -185,7 +186,9 @@ export const MockRuleHandlingForm = ({redirectToPreviousPage, onSubmitShowModal,
     
     // set response headers
     let headers = formikValues.headers;
-    if (headers.length > 0 && typeof headers === 'string') {
+    if (headers.length === 0) {
+      headers = [];
+    } else if (headers.length > 0 && typeof headers === 'string') {
       let rawHeaders = (formikValues.headers as unknown as string).split(",").map(tag => tag.trim());
       let splitHeaders = rawHeaders.map(header => {
         let split = header.split(":");
@@ -194,9 +197,11 @@ export const MockRuleHandlingForm = ({redirectToPreviousPage, onSubmitShowModal,
       headers = splitHeaders;
     }
 
-    // set parachute response headers
+    // set parachute injected params
     let injected_parameters = formikValues.injected_parameters;
-    if (injected_parameters.length > 0 && typeof injected_parameters === 'string') {
+    if (injected_parameters.length === 0) {
+      injected_parameters = [];
+    } else if (injected_parameters.length > 0 && typeof injected_parameters === 'string') {
       injected_parameters = (injected_parameters as unknown as string).split(",").map(tag => tag.trim());
     }
 
@@ -272,7 +277,10 @@ export const MockRuleHandlingForm = ({redirectToPreviousPage, onSubmitShowModal,
       <Paper elevation={8} sx={{ marginBottom: 2, borderRadius: 4, p: 4 }}>
         <Grid container alignItems={"center"} spacing={1} mb={2}>
           <Grid item xs={11}>
-            <Typography variant="h5">Conditions</Typography>
+            <Typography variant="h5">
+              Conditions
+              {getRuleConditionTooltip()}
+            </Typography>
           </Grid>
         </Grid>
         <Divider style={{ marginBottom: 20 }} />
@@ -345,7 +353,7 @@ export const MockRuleHandlingForm = ({redirectToPreviousPage, onSubmitShowModal,
             <TextField id="status" label="Status code" type="number" placeholder="200" value={formik.values.status} onChange={formik.handleChange} error={formik.touched.status && Boolean(formik.errors.status)} InputLabelProps={{ shrink: true }} inputProps={{ max: 599, min: 200}} sx={{ width: "100%" }}/>
           </Grid>
           <Grid item xs={10}>
-            <TextField id="injected_parameters" label="Injected parameters (split by comma)" placeholder="req.param1.value1, req.param2.value2, ..." value={formik.values.injected_parameters} onChange={formik.handleChange} error={formik.touched.injected_parameters && Boolean(formik.errors.injected_parameters)} InputLabelProps={{ shrink: true }} sx={{ width: "100%" }}/>
+            <TextField id="injected_parameters" label={<>Injected parameters (split by comma) {getInjectedParameterTooltip()}</>} placeholder="req.param1.value1, req.param2.value2, ..." value={formik.values.injected_parameters} onChange={formik.handleChange} error={formik.touched.injected_parameters && Boolean(formik.errors.injected_parameters)} InputLabelProps={{ shrink: true }} sx={{ width: "100%" }}/>
           </Grid>
         </Grid>
         <Grid container alignItems={"center"} spacing={1} mb={2}>
@@ -355,7 +363,7 @@ export const MockRuleHandlingForm = ({redirectToPreviousPage, onSubmitShowModal,
         </Grid>
         <Grid container alignItems={"center"} spacing={1} mb={2}>
           <Grid item xs={12}>
-            <TextField id="body" multiline label="Body response (in string, XML or JSON)" rows={20} value={formik.values.body} onChange={formik.handleChange} InputLabelProps={{ shrink: true }} sx={{ width: '100%', fontSize: '8px', typography: 'caption' }} />
+            <TextField id="body" multiline label="Body response (in string, XML or JSON)" rows={20} value={formik.values.body} onChange={formik.handleChange} InputProps={{ sx: {fontSize: '8px', typography: 'caption'} }} InputLabelProps={{ shrink: true }} sx={{ width: '100%', fontSize: '8px', typography: 'caption' }} />
           </Grid>
         </Grid>    
 

--- a/src/util/routes.tsx
+++ b/src/util/routes.tsx
@@ -31,7 +31,7 @@ export default class Routes extends React.Component {
                 <Route path="/mocker/mock-resources/:id/rules/create" exact component={CreateMockRule} />
                 <Route path="/mocker/mock-resources/:id/rules/:ruleid/edit" exact component={EditMockRule} />
                 
-                <Route path="/mocker/simulation/" exact render={props => { return <ShowSimulationMainPage {...props} /> }} />
+                <Route path="/mocker/simulation" exact render={props => { return <ShowSimulationMainPage {...props} /> }} />
                 <Route component={NotFound} />
               </Switch>
             </Layout>

--- a/src/util/tooltips.tsx
+++ b/src/util/tooltips.tsx
@@ -1,0 +1,42 @@
+import { Help } from "@mui/icons-material"
+import { Tooltip } from "@mui/material"
+import React, { ReactNode } from "react"
+
+export const getSpecialHeadersTooltip = () => {
+    return getHelpTooltip(
+        <>This field represents the set of special headers to be tightly bound to the mock resource.<br/><br/>
+        If a request is compliant with the mock resource and contains these headers with the defined values, Mocker may evaluate the mock rules and return a response.<br/><br/>
+        If a request does not have all the headers defined with the same set values, Mocker does not consider the request to be compliant with this mock resource.<br/><br/>
+        The evaluation of the headers and their values in the request is case insensitive. </>
+    );
+} 
+
+export const getActivationStatusTooltip = () => {
+    return getHelpTooltip(
+        <> This field represents the activation status of the mock resource.<br/><br/>
+        If the mock resource is in "active" state, Mocker can evaluate its rules if the request is compliant with this resource.<br/><br/>
+        If the mock resource is in "inactive" state, Mocker does not evaluate the rules that make it up and returns a generic error message.</>
+    );
+}
+
+export const getRuleConditionTooltip = () => {
+    return getHelpTooltip(
+        <>This field represents the list of conditions, sequentially analyzed in AND, that a request must follows in order to receive the mock response defined for this rule.</>
+    );
+}
+
+export const getInjectedParameterTooltip = () => {
+    return getHelpTooltip(
+        <>These fields represents the set of parameter that can be injected in the response body.<br/><br/>
+        These parameters are taken from request body and can be used for dynamic values in mock response using the format {'${NAME}'}.<br/><br/>
+        If no value is retrievable from request, the field value is set as empty.</>
+    );
+}
+
+export const getHelpTooltip = (text: ReactNode) => {
+    return (
+        <Tooltip title={<div>{text}</div>}>
+          <Help sx={{ color: "#61affe", paddingLeft: '5px' }}></Help>
+        </Tooltip>
+    );
+}

--- a/src/util/utilities.tsx
+++ b/src/util/utilities.tsx
@@ -3,6 +3,10 @@ import { toast } from "react-toastify";
 import { Condition_typeEnum, MockCondition } from "../api/generated/mocker-config/MockCondition";
 import { ComplexContentTypeEnum } from "./constants";
 import { Http_methodEnum, MockResource } from "../api/generated/mocker-config/MockResource";
+import { Box, Divider, Typography } from "@mui/material";
+import { MockResponse } from "../api/generated/mocker-config/MockResponse";
+import { getInjectedParameterTooltip } from "./tooltips";
+import xmlFormat from "xml-formatter";
 
 export const appendInList = (list: readonly any[], value: any): any[] => {
   var newList = [];
@@ -13,32 +17,96 @@ export const appendInList = (list: readonly any[], value: any): any[] => {
   return newList;
 }
 
+
 export const stringfyList = (list: readonly any[], mapValue?: (value: any) => string): string => {
+  if (typeof list === 'string') {
+    let stringList = [list];
+    console.log("str:", stringList);
+    return stringList.join(", ");
+  }
   if (mapValue) {
     return list.map((value) => mapValue(value)).join(", ");
-  }
+  } 
   return list.join(", ");
 }
 
-export const generateCURLRequest = (url: string, request?: MockResource): string => {
-  let curl = `curl -X ${request?.http_method} \\\n--location '${url}'`;
-  if (request?.special_headers) {
-    request?.special_headers.forEach((header) => {
+
+export const generateCURLRequest = (url: string, mockResource?: MockResource, serialize?: boolean): string => {
+  let curl = `curl -X ${mockResource?.http_method} \\\n--location '${url}'`;
+  if (mockResource?.special_headers) {
+    mockResource?.special_headers.forEach((header) => {
       curl += ` \\\n--header '${header.name}: ${header.value}'`;
     });
   }
-  if (request?.http_method !== Http_methodEnum.GET && request?.http_method !== Http_methodEnum.DELETE) {
-    curl += ` \\\n--header 'content-type: text'`;
-    curl += ` \\\n--data 'write-here-your-body'`;
+  let contentType = "text/plain";
+  let content = "write-here-your-body";
+  let parachuteRule = mockResource?.rules[mockResource.rules.length - 1];
+  if (parachuteRule !== undefined && parachuteRule.response.body !== undefined) {
+    let decodedBody = atob(parachuteRule.response.body);
+    if (decodedBody.startsWith("{")) {
+      contentType = "application/json";
+      content = '{\n\t"content": "..."\n}';
+    } else if (decodedBody.startsWith("<")) {
+      contentType = "text/xml";
+      content = '<?xml version="1.0" encoding="utf-8"?>\n<Envelope>\n\t<Body>\n\t\t<Content>...</Content>\n\t</Body>\n</Envelope>';
+      if (serialize) {
+        content = btoa(content);
+      }
+    }
+  }
+  curl += ` \\\n--header 'content-type: ${contentType}'`;
+  if (mockResource?.http_method !== Http_methodEnum.GET && mockResource?.http_method !== Http_methodEnum.DELETE) {
+    curl += ` \\\n--data '${content}'`;
   }
   return curl;
 }
 
-export const toastError = (message: string) => {
-    toast.error(() => <div className={"toast-width"}>{message}</div>, {
-      theme: "colored",
-    });
+
+
+
+
+export const getFormattedResponseInfo = (response: MockResponse) => {
+  let headers = response.headers.map(header => 
+    <Typography variant="body2" sx={{ fontSize: '14px'}}>
+      <b>{header.name}:</b> <Typography variant="caption" sx={{ fontSize: '14px'}}>{header.value}</Typography>
+    </Typography>
+  );
+  let injected_parameters = response.injected_parameters && response.injected_parameters.length > 0 ? stringfyList(response.injected_parameters) : 'none'
+  return (
+    <Box>
+      <Typography variant="body2" sx={{ fontSize: '14px'}}>
+        <b>Status:</b> <Typography variant="caption" sx={{ fontSize: '14px'}}>{response.status}</Typography>
+      </Typography>
+      <Typography variant="body2" sx={{ fontSize: '14px', marginBottom: 1 }}>
+        <b>Injectable parameters: </b> 
+        <Typography variant="caption" sx={{ fontSize: '14px'}}>
+          {injected_parameters}
+          {getInjectedParameterTooltip()}
+        </Typography>
+      </Typography>
+      <Divider/>
+      {headers}
+    </Box>
+  );
 }
+
+
+export const getFormattedBody = (body: string | undefined, isEncoded?: boolean) => {
+  let analyzedBody = body;
+  if (analyzedBody === undefined) {
+    return 'No body';
+  }
+  if (isEncoded) {
+    analyzedBody = atob(analyzedBody);
+  }
+  if (analyzedBody.startsWith("{")) {
+    return JSON.stringify(JSON.parse(analyzedBody), null, 2);
+  } else if (analyzedBody.startsWith("<")) {
+    return xmlFormat(analyzedBody, {collapseContent: true});
+  }
+  return analyzedBody;
+}
+
 
 export const getFormattedCondition = (condition: MockCondition) => {
   let conditionValue = <></>;
@@ -74,6 +142,7 @@ export const getFormattedCondition = (condition: MockCondition) => {
   return (<>Field <b>{condition.field_name}</b> in <b>{condition.analyzed_content_type}</b> <b>{condition.field_position}</b> {conditionValue}.</>);
 }
 
+
 export const getFormattedConditionByType = (condition_type: Condition_typeEnum | string) => {
   let conditionValue = "";
   switch (condition_type) {
@@ -108,6 +177,7 @@ export const getFormattedConditionByType = (condition_type: Condition_typeEnum |
   return conditionValue;
 }
 
+
 export const getFormattedComplexContentType = (type: ComplexContentTypeEnum | string) => {
   let value = "";
   switch (type) {
@@ -124,8 +194,22 @@ export const getFormattedComplexContentType = (type: ComplexContentTypeEnum | st
       value = "as header in request";
       break;
     case ComplexContentTypeEnum.URL_STRING:
-      value = "as parameter in request URL";
+      value = "as query parameter in request URL";
       break;
   }
   return value;
+}
+
+
+export const toastOK = (message: string) => {
+  toast.success(() => <div className={"toast-width"}>{message}</div>, {
+    theme: "colored", autoClose: 2000
+  });
+}
+
+
+export const toastError = (message: string) => {
+    toast.error(() => <div className={"toast-width"}>{message}</div>, {
+      theme: "colored", autoClose: 2000
+    });
 }


### PR DESCRIPTION
This PR contains several new functionalities added on Mocker domain: the most important is the completing of Mocker simulator, a dedicated page that permits to directly tests the created mock resource and simulate a communication between a custom system and the same Mocker system.  
Also, several other minor bugs are resolved and some little features are added in order to facilitate UX.

#### List of Changes
 - Added Mocker simulator page
 - Resolved bug on swap functionality, accepting status 400 if more rules have same order  
 - Added other help tooltips in various pages
 - Several other little fixes, too many and too small to be described

#### Motivation and Context
These changes adds a new functionalities and several bug fixes on current portal basecode

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):
##### Request section
![image](https://github.com/pagopa/pagopa-shared-toolbox/assets/117269497/79b2666b-1a16-41d5-8c05-82f5621d188d)

##### Response section
![image](https://github.com/pagopa/pagopa-shared-toolbox/assets/117269497/bf357f0d-0863-49e1-86e1-f30df1b3aeae)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.