### PR TITLE
feat: New 'duplicate mock rule' feature and various bugfix

### DIFF
--- a/.github/workflows/release_deploy.yml
+++ b/.github/workflows/release_deploy.yml
@@ -72,14 +72,14 @@ jobs:
         run: echo "semver=${{env.SEMVER}}" >> $GITHUB_OUTPUT
 
       # Set Environment
-      - run: echo "ENVIRNOMENT=${{ inputs.environment}}" >> $GITHUB_ENV
+      - run: echo "ENVIRONMENT=${{ inputs.environment}}" >> $GITHUB_ENV
 
       - if: ${{ inputs.environment == null || inputs.environment == '' }}
-        run: echo "ENVIRNOMENT=dev" >> $GITHUB_ENV
+        run: echo "ENVIRONMENT=dev" >> $GITHUB_ENV
 
       - id: get_env
         name: Set Output
-        run: echo "environment=${{env.ENVIRNOMENT}}" >> $GITHUB_OUTPUT
+        run: echo "environment=${{env.ENVIRONMENT}}" >> $GITHUB_OUTPUT
 
   release:
     name: Create a New Release
@@ -116,7 +116,7 @@ jobs:
 
       - name: Build
         run: |
-          export REACT_APP_ENV='${{ inputs.environment }}'
+          export REACT_APP_ENV='${{ needs.setup.outputs.environment }}'
 
           export REACT_APP_MOCKERCONFIG_HOST='${{ vars.MOCKER_CONFIG_HOST }}'
           export REACT_APP_MOCKERCONFIG_BASEPATH='${{ vars.MOCKER_CONFIG_BASEPATH }}'
@@ -164,7 +164,7 @@ jobs:
           tenant-id: ${{ secrets.TENANT_ID }}
           subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
 
-      - name: Deploy ${{ inputs.environment }}
+      - name: Deploy ${{ needs.setup.outputs.environment }}
         uses: azure/CLI@v1
         with:
           azcliversion: latest

--- a/src/assets/resources/login.md
+++ b/src/assets/resources/login.md
@@ -1,3 +1,14 @@
-## pagoPA Shared Toolbox ##
-Welcome to **pagoPA Shared Toolbox**!  
-...
+## pagoPA Shared Toolbox
+
+Welcome to **pagoPA Shared Toolbox**!
+
+### What is pagoPA Shared Toolbox? 
+
+The portal aims to be the centralised entry point for all services used by the pagoPA platform teams.  
+Through the pagoPA Shared Toolbox, it is possible to monitor the services present on the DEV, UAT and PROD environments,  
+carrying out maintenance or census operations facilitated by an experience more interactive and user-friendly than a "barebone" APIs.  
+
+### How to access?
+
+To access it, it is necessary to be part of the teams operating on the pagoPA platform. If you are unable to enter the portal,  
+ask to [PagoPa Tech](mailto:pagopa-tech@pagopa.it) team members to add you.

--- a/src/pages/mocker/forms/MockResourceHandlingForm.tsx
+++ b/src/pages/mocker/forms/MockResourceHandlingForm.tsx
@@ -70,10 +70,10 @@ export const MockResourceHandlingForm = ({redirectToPreviousPage, onSubmitShowMo
         special_headers: [],
         rules: [
           {
-            name: "Parachute Rule",
+            name: "Default Rule",
             conditions: [],
             order: 10000,
-            tags: ["Parachute"],
+            tags: ["Default"],
             is_active: true,
             response: {
               status: 200,
@@ -107,7 +107,7 @@ export const MockResourceHandlingForm = ({redirectToPreviousPage, onSubmitShowMo
 
       mockResource.rules[0].response.status = mockResource.status;
 
-      // set parachute body
+      // set default body
       let body = mockResource.body;
       mockResource.rules[0].response.body = btoa(body ? body : '');
 
@@ -122,7 +122,7 @@ export const MockResourceHandlingForm = ({redirectToPreviousPage, onSubmitShowMo
         mockResource.special_headers = headers;
       }
 
-      // set parachute response headers
+      // set default response headers
       if (mockResource.headers.length > 0 && typeof mockResource.headers === 'string') {
         let rawHeaders = (mockResource.headers as unknown as string).split(",").map(tag => tag.trim());
         let headers = rawHeaders.map(header => {
@@ -132,7 +132,7 @@ export const MockResourceHandlingForm = ({redirectToPreviousPage, onSubmitShowMo
         mockResource.rules[0].response.headers = headers;
       }
 
-      // set parachute response headers
+      // set default response headers
       if (mockResource.injected_parameters.length > 0 && typeof mockResource.injected_parameters === 'string') {
         mockResource.rules[0].response.injected_parameters = (mockResource.injected_parameters as unknown as string).split(",").map(tag => tag.trim());
       }
@@ -206,7 +206,7 @@ export const MockResourceHandlingForm = ({redirectToPreviousPage, onSubmitShowMo
         <Paper elevation={8} sx={{ marginBottom: 2, borderRadius: 4, p: 4 }}>
           <Grid container alignItems={"center"} spacing={1} mb={2}>
             <Grid item xs={11}>
-              <Typography variant="h5">Parachute rule response</Typography>
+              <Typography variant="h5">Default rule response</Typography>
             </Grid>
           </Grid>
           <Divider style={{ marginBottom: 20 }} />
@@ -225,7 +225,7 @@ export const MockResourceHandlingForm = ({redirectToPreviousPage, onSubmitShowMo
           </Grid>
           <Grid container alignItems={"center"} spacing={1} mb={2}>
             <Grid item xs={12}>
-              <TextField id="body" multiline label="Parachute body response (in string, XML or JSON)" rows={20} value={formik.values.body} onChange={formik.handleChange} InputProps={{ sx: {fontSize: '8px', typography: 'caption'} }} InputLabelProps={{ shrink: true }} sx={{ width: '100%', fontSize: '8px', typography: 'caption' }} />
+              <TextField id="body" multiline label="Default body response (in string, XML or JSON)" rows={20} value={formik.values.body} onChange={formik.handleChange} InputProps={{ sx: {fontSize: '8px', typography: 'caption'} }} InputLabelProps={{ shrink: true }} sx={{ width: '100%', fontSize: '8px', typography: 'caption' }} />
             </Grid>
           </Grid>
         </Paper>

--- a/src/pages/mocker/simulator/ShowSimulationMainPage.tsx
+++ b/src/pages/mocker/simulator/ShowSimulationMainPage.tsx
@@ -33,9 +33,9 @@ interface IState {
 }
 
 interface IResponse {
-  body: string,
+  body?: string,
   status: number,
-  headers: any,
+  headers?: any,
   time: number
 }
 
@@ -86,23 +86,23 @@ export default class ShowSimulationMainPage extends React.Component<IProps, ISta
     })
     .then((res) => {
       let response = {
-        body: res.data,
+        body: typeof res.data === 'string' ? res.data : JSON.stringify(res.data),
         status: res.status,
         headers: res.headers,
         time: 0
       }
       this.setState({response});
-      console.log(this.state.response);
     })
     .catch((res) => {
-      let response = {
-        body: res.response.data,
-        status: res.response.status,
-        headers: res.response.headers,
-        time: 0
+      if (res.response) {
+        let response = {
+          body: typeof res.response === 'string' ? res.response :JSON.stringify(res.response.data),
+          status: res.response.status,
+          headers: res.response.headers,
+          time: 0
+        }
+        this.setState({response});
       }
-      this.setState({response});
-      console.log(this.state.response);
     });
   }
 

--- a/src/pages/others/NotFound.tsx
+++ b/src/pages/others/NotFound.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Alert } from "react-bootstrap";
 
 const NotFound = () => (
-  <Alert className={"col-md-12"} color={"#1976d2"}>
+  <Alert className={"col-md-12"} color={"red"}>
     Oops! The page did not exists!
   </Alert>
 );

--- a/src/util/utilities.tsx
+++ b/src/util/utilities.tsx
@@ -21,7 +21,6 @@ export const appendInList = (list: readonly any[], value: any): any[] => {
 export const stringfyList = (list: readonly any[], mapValue?: (value: any) => string): string => {
   if (typeof list === 'string') {
     let stringList = [list];
-    console.log("str:", stringList);
     return stringList.join(", ");
   }
   if (mapValue) {
@@ -40,9 +39,9 @@ export const generateCURLRequest = (url: string, mockResource?: MockResource, se
   }
   let contentType = "text/plain";
   let content = "write-here-your-body";
-  let parachuteRule = mockResource?.rules[mockResource.rules.length - 1];
-  if (parachuteRule !== undefined && parachuteRule.response.body !== undefined) {
-    let decodedBody = atob(parachuteRule.response.body);
+  let defaultRule = mockResource?.rules[mockResource.rules.length - 1];
+  if (defaultRule !== undefined && defaultRule.response.body !== undefined) {
+    let decodedBody = atob(defaultRule.response.body);
     if (decodedBody.startsWith("{")) {
       contentType = "application/json";
       content = '{\n\t"content": "..."\n}';
@@ -199,6 +198,17 @@ export const getFormattedComplexContentType = (type: ComplexContentTypeEnum | st
   }
   return value;
 }
+
+
+export const getFirstAvailableOrder = (mockResource?: MockResource) => {
+  const rulesWithoutDefault = mockResource?.rules.slice(0, length - 1) || [];
+  if (rulesWithoutDefault.length == 0) {
+    return 1;
+  } else {
+    return rulesWithoutDefault[rulesWithoutDefault.length - 1].order + 1;
+  }
+}
+
 
 
 export const toastOK = (message: string) => {


### PR DESCRIPTION
This PR contains a new feature that permits to duplicate an existing rule in order to make more simple the creation of set of mock rules.  
Also, a little bug on swap rule that caused a wrong value set is resolved, permitting the correct change of order values.  

#### List of Changes
 - Added new feature for duplicate an existing mock rule
 - Resolved bug on mock rule order swap
 - Resolved bug on GitHub Action's automatic deploy pipeline made after a PR merge
 - Set default rule (previously named parachute rule) as not full editable, blocking user to wrongly change parameters  
 - Other minor fixes on style and UX

#### Motivation and Context
These change permits to upgrade the user experience, adding a new functionality and fixing old ones

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.