### PR TITLE
feat: added filters for mock resource detailed search

### DIFF
--- a/src/util/apiclient.ts
+++ b/src/util/apiclient.ts
@@ -44,11 +44,13 @@ const onRedirectToLogin = () => {
 
 export const MockerConfigApi = {
 
-    getMockResources: async (token: string, limit: number, page: number): Promise<MockResourceList> => {
+    getMockResources: async (token: string, limit: number, page: number, name?: string, tag?: string): Promise<MockResourceList> => {
         const result = await apiClient.getMockResources({
             Authorization: setJWTToken(token),
             limit, 
-            page
+            page,
+            name,
+            tag
         });
         return extractResponse(result, 200, onRedirectToLogin);
     },


### PR DESCRIPTION
This PR contains a new feature related to mock resource list. This functionality permits to executed a filtered search, based on the values of mock resource name and mock resource tag. The filter permits to automatically starts the request towards Mocker configurator after a debouncing of 500ms, permitting to search with partial values in LIKE format.   

#### List of Changes
 - Added search filters for mock resource list

#### Motivation and Context
This feature permits to facilitate the search of mock resources, filtering for specific fields.

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):
![Screenshot 2024-02-24 alle 10 48 02](https://github.com/pagopa/pagopa-shared-toolbox/assets/117269497/72139933-71f0-453c-8ba0-a703561b0df5)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.